### PR TITLE
DL-12441: Replaced joda.time with java.time

### DIFF
--- a/app/uk/gov/hmrc/awrslookup/controllers/LookupController.scala
+++ b/app/uk/gov/hmrc/awrslookup/controllers/LookupController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.awrslookup.controllers
 
 import javax.inject.Inject
 import metrics.AwrsLookupMetrics
-import org.joda.time.DateTime
+import java.time.LocalDate
 import play.api.Environment
 import play.api.libs.json.{JsSuccess, Json}
 import play.api.mvc._
@@ -29,7 +29,6 @@ import uk.gov.hmrc.awrslookup.services.EtmpLookupService
 import uk.gov.hmrc.awrslookup.utils.LoggingUtils
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import play.api.libs.json.JodaReads._
 
 import scala.concurrent.ExecutionContext
 
@@ -55,10 +54,10 @@ class LookupController @Inject()(val environment: Environment,
     lookupResponse.status match {
       case OK =>
         val status = (lookupResponse.json \ "awrsStatus").validate[String]
-        val endDate = (lookupResponse.json \ "endDate").validate[DateTime]
-        val earliestDate = DateTime.parse("2017-04-01")
+        val endDate = (lookupResponse.json \ "endDate").validate[LocalDate]
+        val earliestDate = LocalDate.parse("2017-04-01")
         (status, endDate) match {
-          case (_: JsSuccess[String], _: JsSuccess[DateTime]) =>
+          case (_: JsSuccess[String], _: JsSuccess[LocalDate]) =>
             if (status.get.toLowerCase != "approved" && (endDate.get.isBefore(earliestDate) || endDate.get == earliestDate)) {
               doAuditing(apiType, "Search Result", "success - capped (Prior 01/04/2017)", loggingUtils.eventTypeSuccess, metrics.incrementSuccessCounter)
               NotFound(referenceNotFoundString)

--- a/app/uk/gov/hmrc/awrslookup/models/etmp/formatters/EtmpDateReaderTemp.scala
+++ b/app/uk/gov/hmrc/awrslookup/models/etmp/formatters/EtmpDateReaderTemp.scala
@@ -15,10 +15,10 @@
  */
 
 package uk.gov.hmrc.awrslookup.models.etmp.formatters
-
-import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormat
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import play.api.libs.json.{JsResult, JsSuccess, JsValue, Reads}
+import scala.util.Try
 
 // TODO remove this object/trait after 1st April
 
@@ -28,18 +28,20 @@ trait EtmpDateReaderTemp extends Reads[String] {
 
   val earliestDateString = "2017-04-01"
 
-  val etmpDatePattern = "yyyy-MM-dd"
+  val etmpDatePattern = "yyyy-M-d"
 
   val frontEndDatePattern = "dd MMMM yyyy"
 
-  val parseDate = (str: JsResult[String]) => DateTime.parse(str.get, DateTimeFormat.forPattern(etmpDatePattern))
+  val parseDate: JsResult[String] => LocalDate = (str: JsResult[String]) => Try(LocalDate.parse(str.get, DateTimeFormatter.ofPattern(etmpDatePattern))).fold(
+    _ => LocalDate.parse(str.get, DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+    localDate => localDate
+  )
 
-  val earliestPossibleDate = DateTime.parse(earliestDateString, DateTimeFormat.forPattern(etmpDatePattern))
+  val earliestPossibleDate: LocalDate = LocalDate.parse(earliestDateString, DateTimeFormatter.ofPattern(etmpDatePattern))
 
   override def reads(json: JsValue): JsResult[String] = {
     val str = json.validate[String]
     val dateTime = parseDate(str)
-    JsSuccess(dateTime.toString(frontEndDatePattern))
+    JsSuccess(dateTime.format(DateTimeFormatter.ofPattern(frontEndDatePattern)))
   }
-
 }

--- a/app/uk/gov/hmrc/awrslookup/models/frontend/AwrsStatus.scala
+++ b/app/uk/gov/hmrc/awrslookup/models/frontend/AwrsStatus.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.awrslookup.models.frontend
 
-import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormat
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import play.api.libs.json._
 import uk.gov.hmrc.awrslookup.models.etmp.formatters.EtmpDateReader
 
@@ -73,7 +73,7 @@ object AwrsStatus {
 
     def isDeregDateInTheFuture(endDate: Option[String]): Boolean =
       endDate match {
-        case Some(date) => DateTime.parse(date, DateTimeFormat.forPattern(EtmpDateReader.frontEndDatePattern)).isAfter(DateTime.now())
+        case Some(date) => LocalDate.parse(date, DateTimeFormatter.ofPattern(EtmpDateReader.frontEndDatePattern)).isAfter(LocalDate.now())
         case _ => false // TODO should never happen but should we throw an exception instead?
       }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -14,8 +14,7 @@ object AppDependencies {
 
     ws,
     "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "7.19.0",
-    "uk.gov.hmrc"       %% "domain"                    % domainVersion,
-    "com.typesafe.play" %% "play-json-joda"            % "2.9.4"
+    "uk.gov.hmrc"       %% "domain"                    % domainVersion
   )
 
   trait TestDependencies {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.15.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.18.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 


### PR DESCRIPTION
Replaced DateTime with LocalDate as ultimately the result in each case was specically a date only (tranforming or extracting only the date element from the origin DateTime function)